### PR TITLE
Add property list with EasyBroker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ src/
 ├── App.jsx
 ├── main.jsx
 ├── components/
-│   └── ChatbotWidget.jsx
+│   ├── ChatbotWidget.jsx
+│   └── PropertyList.jsx
+├── services/
+│   └── easyBrokerApi.js
 └── views/
     └── Home.jsx
 ```
@@ -27,6 +30,7 @@ Crea un archivo `.env` con el siguiente contenido:
 
 ```
 VITE_OPENAI_API_KEY=tu_clave_de_openai
+VITE_EASYBROKER_TOKEN=tu_token_de_easybroker
 ```
 
 ⚠️ Nunca subas .env al repositorio (está ignorado en .gitignore)

--- a/src/components/PropertyList.jsx
+++ b/src/components/PropertyList.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react'
+import { easyBrokerGet } from '../services/easyBrokerApi'
+
+const PropertyList = () => {
+  const [properties, setProperties] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    easyBrokerGet('/properties?page=1&limit=10')
+      .then((data) => {
+        setProperties(data.content || [])
+        setLoading(false)
+      })
+      .catch((err) => {
+        console.error(err)
+        setError('Error al cargar propiedades')
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) return <p>Cargando propiedades...</p>
+  if (error) return <p>{error}</p>
+
+  return (
+    <ul>
+      {properties.map((prop) => (
+        <li key={prop.public_id}>{prop.title}</li>
+      ))}
+    </ul>
+  )
+}
+
+export default PropertyList

--- a/src/services/easyBrokerApi.js
+++ b/src/services/easyBrokerApi.js
@@ -1,0 +1,15 @@
+const API_URL = 'https://api.stagingeb.com/v1'
+
+export async function easyBrokerGet(endpoint) {
+  const token = import.meta.env.VITE_EASYBROKER_TOKEN
+  const res = await fetch(`${API_URL}${endpoint}`, {
+    headers: {
+      'X-Authorization': token,
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`EasyBroker error ${res.status}: ${text}`)
+  }
+  return res.json()
+}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import PropertyList from '../components/PropertyList'
 
 const Home = () => {
   return (
     <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h1>Bienvenido a Doka House 🏠</h1>
       <p>Explora propiedades con ayuda de nuestro asistente inteligente.</p>
+      <PropertyList />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add EasyBroker API helper for authenticated requests
- list properties from EasyBroker in a new PropertyList component
- show PropertyList inside Home view
- document new service and env var

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68797b7ffe30832e9c855b6228fafc63