### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ npm run dev      # Inicia entorno local (localhost:5173)
 npm run build    # Genera versión optimizada
 ```
 
+## 🌐 Despliegue
+
+El repositorio cuenta con un flujo de GitHub Actions que compila la aplicación y
+la publica en GitHub Pages cada vez que se actualiza `main`. Revisa la propiedad
+`base` en `vite.config.js` para que coincida con el nombre de tu repositorio
+(`base: '/dokahouse/'`).
+
 📩 Contacto
 
 Paulette Barrales

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: '/dokahouse/',
 })


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy `dist` to GitHub Pages
- document how to use the workflow and configure `vite.config.js`
- set Vite base path for GitHub Pages

## Testing
- `npm run build` *(fails: `node` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68798163d3f4832ea5ca94dc375a3132