### PR TITLE
Add dark mode toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+dist/

--- a/index.html
+++ b/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DokaBot</title>
+    <link rel="stylesheet" href="/src/theme.css" />
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" class="light"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import Home from './views/Home'
 import ChatbotWidget from './components/ChatbotWidget'
+import ThemeToggle from './components/ThemeToggle'
 
 function App() {
   return (
     <>
       <Home />
       <ChatbotWidget />
+      <ThemeToggle />
     </>
   )
 }

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react'
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState('light')
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  useEffect(() => {
+    const root = document.getElementById('root')
+    if (root) {
+      root.classList.remove('light', 'dark')
+      root.classList.add(theme)
+    }
+  }, [theme])
+
+  return (
+    <button
+      onClick={toggleTheme}
+      style={{
+        position: 'fixed',
+        top: '1rem',
+        right: '1rem',
+        background: 'none',
+        border: 'none',
+        fontSize: '2rem',
+        cursor: 'pointer',
+      }}
+    >
+      {theme === 'light' ? '🌞' : '🌜'}
+    </button>
+  )
+}
+
+export default ThemeToggle

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,15 @@
+.light {
+  background-color: #ffffff;
+  color: #000000;
+  min-height: 100vh;
+}
+
+.dark {
+  background-color: #121212;
+  color: #ffffff;
+  min-height: 100vh;
+}
+
+body {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add global theme stylesheet
- link stylesheet in `index.html` and default to light theme
- implement toggle component for sun/moon button
- include toggle component in `App`
- ignore build output

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879779bcc30832ea63a815604182fa9