### PR TITLE
Fix dark mode theme class sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,11 @@ function App() {
 
   useEffect(() => {
     document.body.className = darkMode ? 'dark' : ''
+    const root = document.getElementById('root')
+    if (root) {
+      root.classList.remove('light', 'dark')
+      root.classList.add(darkMode ? 'dark' : 'light')
+    }
   }, [darkMode])
 
   return (

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -13,6 +13,8 @@ const ThemeToggle = () => {
       root.classList.remove('light', 'dark')
       root.classList.add(theme)
     }
+    document.body.classList.remove('light', 'dark')
+    document.body.classList.add(theme)
   }, [theme])
 
   return (


### PR DESCRIPTION
## Summary
- sync body and root classes when toggling theme
- keep tagline visible in dark mode

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a635d130c832e9a4a67f4d13abeae