### PR TITLE
Add EasyBroker properties page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Hero from './views/Hero'
 import Features from './views/Features'
+import Properties from './views/Properties'
 import ChatbotWidget from './components/ChatbotWidget'
 import ThemeToggle from './components/ThemeToggle'
 import Testimonials from './components/Testimonial'
@@ -14,6 +15,7 @@ function App() {
       <Hero />
       <Features />
       <ChatbotWidget />
+      <Properties />
       <Testimonials />
       <ThemeToggle />
     </>

--- a/src/components/PropertyList.jsx
+++ b/src/components/PropertyList.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { easyBrokerGet } from '../services/easyBrokerApi'
+import PropertyCard from './PropertyCard'
 
 const PropertyList = () => {
   const [properties, setProperties] = useState([])
@@ -23,11 +24,23 @@ const PropertyList = () => {
   if (error) return <p>{error}</p>
 
   return (
-    <ul>
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '1rem',
+      }}
+    >
       {properties.map((prop) => (
-        <li key={prop.public_id}>{prop.title}</li>
+        <PropertyCard
+          key={prop.public_id}
+          title={prop.title}
+          price={prop.operations?.[0]?.amount}
+          image={prop.property_images?.[0]?.url_medium}
+          location={prop.location?.name}
+        />
       ))}
-    </ul>
+    </div>
   )
 }
 

--- a/src/views/Properties.jsx
+++ b/src/views/Properties.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import PropertyList from '../components/PropertyList'
+
+const Properties = () => (
+  <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+    <h1>Propiedades disponibles</h1>
+    <PropertyList />
+  </main>
+)
+
+export default Properties


### PR DESCRIPTION
## Summary
- show properties with a card layout
- add new `Properties` page
- include new page in the main App

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a6a3459ac832ea6f9867d06854140