### PR TITLE
Add backend proxy for EasyBroker API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,11 @@ jobs:
           node-version: 18
           cache: npm
 
-      - name: Install dependencies
+      - name: Install frontend dependencies
         run: npm ci
+
+      - name: Install backend dependencies
+        run: npm ci --prefix backend
 
       - name: Build project
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Crea un archivo `.env` con el siguiente contenido:
 
 ```
 VITE_OPENAI_API_KEY=tu_clave_de_openai
-VITE_EASYBROKER_TOKEN=tu_token_de_easybroker
+EASYBROKER_TOKEN=tu_token_de_easybroker
 ```
 
 ⚠️ Nunca subas .env al repositorio (está ignorado en .gitignore)
@@ -40,7 +40,8 @@ VITE_EASYBROKER_TOKEN=tu_token_de_easybroker
 
 ```
 npm install      # Instala dependencias
-npm run dev      # Inicia entorno local (localhost:5173)
+npm run dev      # Inicia frontend en localhost:5173
+cd backend && npm run dev  # Inicia backend en localhost:3000
 npm run build    # Genera versión optimizada
 ```
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const cors = require('cors');
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+const path = require('path');
+require('dotenv').config();
+
+const API_BASE = 'https://api.stagingeb.com/v1';
+const PORT = process.env.PORT || 3000;
+
+const app = express();
+
+app.use(cors({ origin: 'http://localhost:5173' }));
+app.use(express.json());
+
+app.use('/api', async (req, res) => {
+  try {
+    const url = API_BASE + req.path + (req.originalUrl.includes('?') ? req.originalUrl.substring(req.originalUrl.indexOf('?')) : '');
+    const options = {
+      method: req.method,
+      headers: {
+        'X-Authorization': process.env.EASYBROKER_TOKEN,
+        'Content-Type': 'application/json',
+      },
+    };
+    if (req.method !== 'GET' && req.body && Object.keys(req.body).length) {
+      options.body = JSON.stringify(req.body);
+    }
+    const response = await fetch(url, options);
+    const data = await response.text();
+
+    res.status(response.status);
+    response.headers.forEach((value, name) => {
+      res.setHeader(name, value);
+    });
+    res.send(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Proxy error' });
+  }
+});
+
+if (process.env.NODE_ENV === 'production') {
+  const distPath = path.join(__dirname, '../dist');
+  app.use(express.static(distPath));
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(distPath, 'index.html'));
+  });
+}
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dokahouse-backend",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/src/services/easyBrokerApi.js
+++ b/src/services/easyBrokerApi.js
@@ -1,12 +1,7 @@
-const API_URL = 'https://api.stagingeb.com/v1'
+const API_URL = '/api'
 
 export async function easyBrokerGet(endpoint) {
-  const token = import.meta.env.VITE_EASYBROKER_TOKEN
-  const res = await fetch(`${API_URL}${endpoint}`, {
-    headers: {
-      'X-Authorization': token,
-    },
-  })
+  const res = await fetch(`${API_URL}${endpoint}`)
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`EasyBroker error ${res.status}: ${text}`)

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: '/dokahouse/',
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add Express backend proxy for EasyBroker API
- update EasyBroker service to hit local proxy
- proxy `/api` path in dev server
- document new environment variable and dev steps
- update GitHub Actions workflow to install backend deps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687be8903f4c832e83f52147cd585357